### PR TITLE
Add README install instructions for the Moderne CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,33 @@
 # chocolatey-moderne
 
-chocolatey package repository
+Chocolatey package definitions for [Moderne](https://moderne.io/) tools.
 
+## Install the Moderne CLI
+
+From an elevated PowerShell or `cmd` prompt:
+
+```powershell
+choco install mod --prerelease
+```
+
+The `--prerelease` flag is required because the `mod` package is published as a pre-release.
+
+To install a specific version:
+
+```powershell
+choco install mod --version 4.2.1 --prerelease
+```
+
+To upgrade to the latest version:
+
+```powershell
+choco upgrade mod --prerelease
+```
+
+After installation, verify with:
+
+```powershell
+mod --version
+```
+
+See the [Moderne CLI installation guide](https://docs.moderne.io/user-documentation/moderne-cli/getting-started/cli-intro/?os=windows#installation-and-configuration) for full instructions.


### PR DESCRIPTION
## Summary
- Replace the placeholder README with quick install instructions for the `mod` Chocolatey package.
- Cover install, version-pinned install, upgrade, and verification, all using `--prerelease` (required since the package is published as a pre-release).
- Link to the Windows-specific section of the official Moderne CLI installation guide.

## Test plan
- [ ] Render the README on GitHub and confirm formatting/links look correct.